### PR TITLE
Fix network resets for Ubuntu Touch

### DIFF
--- a/server/CommandListener.cpp
+++ b/server/CommandListener.cpp
@@ -251,9 +251,10 @@ CommandListener::CommandListener() :
 
     gCtls->bandwidthCtrl.enableBandwidthControl(false);
 
-    if (int ret = RouteController::Init(NetworkController::LOCAL_NET_ID)) {
-        ALOGE("failed to initialize RouteController (%s)", strerror(-ret));
-    }
+    /// Commented out because this resets network connections on container startup
+    // if (int ret = RouteController::Init(NetworkController::LOCAL_NET_ID)) {
+    //     ALOGE("failed to initialize RouteController (%s)", strerror(-ret));
+    // }
 }
 
 CommandListener::InterfaceCmd::InterfaceCmd() :


### PR DESCRIPTION
When the Android container starts on Ubuntu Touch, it causes a reset of
all network interfaces. This makes it impossible to debug as the SSH
connection is dropped and a new one cannot be established. This commit
disables netd's RouteController which causes the reset.

Change-Id: Ib86065450708dd59862f1a7986818c90a1af7acd